### PR TITLE
fixed hardcoded journal + netlog folders

### DIFF
--- a/Thargoid_Interceptor.asl
+++ b/Thargoid_Interceptor.asl
@@ -61,7 +61,7 @@ init {
 	string netlogPath = Path.Combine(
 			vars.installationFolder,
 			"Products",
-			(settings["odyssey"] ? "elite-dangerous-64-odyssey" : "elite-dangerous-64"), // FIXXME: check that
+			(settings["odyssey"] ? "elite-dangerous-odyssey-64" : "elite-dangerous-64"),
 			"Logs"
 		);
 	if (!Directory.Exists(netlogPath)) {

--- a/Thargoid_Interceptor.asl
+++ b/Thargoid_Interceptor.asl
@@ -47,7 +47,6 @@ startup {
 }
 
 init {
-	// Open Journal - Edit journalPath to match where your journal file is
 	string journalPath = Path.Combine(
 		Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
 		"Saved Games",
@@ -59,7 +58,6 @@ init {
 	vars.journalReader = new StreamReader(new FileStream(journalFile.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 	vars.journalReader.ReadToEnd();
 
-	// Open netLog - Edit netLogPath to match where your netLog file is, and note it varies between Horizons and Odyssey!
 	string netlogPath = Path.Combine(
 			vars.installationFolder,
 			"Products",


### PR DESCRIPTION
The netlog folder sadly sits below the installation folder. That means that users will still have to change a path in the auto splitter by hand.

The alternative would be to pull the installation folder from the registry; that’s a PITA + if you install more than one copy (e.g. I have standalone + Epic) then it breaks again.