### PR TITLE
removed null checks from `update`

### DIFF
--- a/Thargoid_Interceptor.asl
+++ b/Thargoid_Interceptor.asl
@@ -115,11 +115,6 @@ init {
 update {
 	current.journalString = vars.journalReader.ReadToEnd();
 	current.netlogString = vars.netlogReader.ReadToEnd();
-
-	if (String.IsNullOrEmpty(current.journalString) && String.IsNullOrEmpty(current.netlogString)) {
-		// Nothing new, don't run any other code blocks
-		return false; 
-	}
 }
 
 start {


### PR DESCRIPTION
This is inconsequential in practice, but a nice exercise in performance/resource optimisation.

We still have to check in `split` and `reset` anyway, since `update` only halts when _both_ log files have no new entries; we still have to check if each individual one has entries later on.

So, this check halts the update cycle when there are no new journal nor netlog lines. That means we’re saving 2 function calls (`split`, `reset`) and 3 `null` checks (2 in `split`, 1 in `reset`).

On the other hand, when there _are_ new journal or netlog lines, we do 2 additional `null` checks.

That means that on every update cycle that we’re not doing anything, we save a few operations. On every update cycle that we _do_ actually do something, we do two additional `null` checks.

