### PR TITLE
fixed file logging option

### DIFF
--- a/Thargoid_Interceptor.asl
+++ b/Thargoid_Interceptor.asl
@@ -161,9 +161,6 @@ start {
 		System.Text.RegularExpressions.Match match = vars.journalEntries["start"].Match(current.journalString);
 		if (match.Success) {
 			// This is necessary if file logging was enabled in the layout settings _after_ the game was started.
-			// There appears to be a race condition here; creating the file, then immediately trying to log to it results in:
-			// “[XXXXX] The process cannot access the file '…\autosplitter.log' because it is being used by another process.”
-			// We can’t wait either though, it would delay the start time.
 			vars.setupLogging();
 
 			vars.log(match.Groups["timestamp"].Value + " - Start run: Combat music detected");


### PR DESCRIPTION
* File logging option is now functional.
* No longer creating the log file and its folder when file logging is turned off.
* Added additional option to auto-flush the log file on every write.
* Changed the output to a persistent `StreamWriter` instead of opening and closing the file every single write.
* Now closing journal and netlog readers properly when the auto splitter is shut down by LiveSplit.

Caveats:

* There is no way to access the setting from `startup`. Hence it’s disabled there no matter the actual setting. Currently that only affects the `vars.log("Autosplitter loaded");` line.
* Since there is no way to be notified of a settings change, they will only take effect a) on loading the game or b) when starting a new run. The latter _might_ introduce a minimal delay in starting the time for the first run after loading the game, then changing the setting. Feel free to test =p
* If file logging is enabled without auto flushing, the file is only updated when the write buffer is full. I added explicit `Flush()`ing to `shutdown` and `reset`. On the plus side that means I/O delay for logging is generally not happening while splitting, reducing inaccuracy there.
* That means you should probably only enable auto flushing for testing purposes, and I added a tooltip to the setting to reflect that.